### PR TITLE
Dimensions: populate colour queues before loop

### DIFF
--- a/src/config/ConfigItemDimensionsPad.cpp
+++ b/src/config/ConfigItemDimensionsPad.cpp
@@ -630,6 +630,8 @@ static void enterToypadMenu(ConfigItemDimensionsPad *item) {
     uint8_t currentIndex = 0;
     item->figureNumbers  = g_dimensionstoypad.GetCurrentFigures();
 
+    populateColorQueues(item);
+
     while (true) {
         uint32_t buttonsTriggered = 0;
 
@@ -764,8 +766,6 @@ static void enterToypadMenu(ConfigItemDimensionsPad *item) {
                 redraw       = true;
             }
         }
-
-        populateColorQueues(item);
 
         if (!item->topColors.empty()) {
             item->topColor = item->topColors.front();


### PR DESCRIPTION
This change makes it so that the colour queues to display are only populated once before the menu loop starts, rather than every time the loop occurs, preventing unnecessary calls to the toypad. Should help the slow speeds seen in https://github.com/deReeperJosh/re_nsyshid/issues/14