### PR TITLE
Dimensions: Respond after 10 no responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ WUT_ROOT := $(DEVKITPRO)/wut
 #-------------------------------------------------------------------------------
 export VERSION_MAJOR	:=	0
 export VERSION_MINOR	:=	4
-export VERSION_PATCH	:=	0
+export VERSION_PATCH	:=	1
 
 #-------------------------------------------------------------------------------
 # TARGET is the name of the output

--- a/src/devices/Dimensions.cpp
+++ b/src/devices/Dimensions.cpp
@@ -521,13 +521,16 @@ std::array<uint8_t, 32> DimensionsToypad::GetStatus() {
             m_queries.pop();
             responded           = true;
             m_wasLastRespFigure = false;
-        } else if (!m_figureAddedRemovedResponses.empty() && m_isAwake && !m_wasLastRespFigure) {
+            m_noResponseCount = 0;
+        } else if (!m_figureAddedRemovedResponses.empty() && m_isAwake && (!m_wasLastRespFigure || m_noResponseCount >= 10)) {
             std::lock_guard lock(m_dimensionsMutex);
             response = m_figureAddedRemovedResponses.front();
             m_figureAddedRemovedResponses.pop();
             responded           = true;
             m_wasLastRespFigure = true;
+            m_noResponseCount = 0;
         } else {
+            m_noResponseCount++;
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     } while (responded == false);

--- a/src/devices/Dimensions.h
+++ b/src/devices/Dimensions.h
@@ -151,6 +151,7 @@ private:
 
     bool m_isAwake = false;
     bool m_wasLastRespFigure = false;
+    uint8_t m_noResponseCount = 0;
 
     std::queue<std::array<uint8_t, 32>> m_figureAddedRemovedResponses;
     std::queue<std::array<uint8_t, 32>> m_queries;


### PR DESCRIPTION
Updates the Dimensions Toypad with a response counter to ensure a response after 10 loops with no response (~1s)

Should fix https://github.com/deReeperJosh/re_nsyshid/issues/23 and https://github.com/deReeperJosh/re_nsyshid/issues/22