### PR TITLE
FS Utils Read/Write fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ WUT_ROOT := $(DEVKITPRO)/wut
 #-------------------------------------------------------------------------------
 export VERSION_MAJOR	:=	0
 export VERSION_MINOR	:=	4
-export VERSION_PATCH	:=	2
+export VERSION_PATCH	:=	3
 
 #-------------------------------------------------------------------------------
 # TARGET is the name of the output

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -221,6 +221,7 @@ DEINITIALIZE_PLUGIN() {
 **/
 ON_APPLICATION_START() {
     initLogging();
+    FSUtils::Initialize();
 
     DEBUG_FUNCTION_LINE("ON_APPLICATION_START of re_nsyshid!");
 }

--- a/src/utils/FSUtils.cpp
+++ b/src/utils/FSUtils.cpp
@@ -48,6 +48,14 @@ int FSUtils::WriteToFile(const char* path, const void* data, uint32_t size)
     FSAFileHandle fileHandle;
     FSError err = FSAOpenFileEx(clientHandle, path, "wb", (FSMode) 0x666, FS_OPEN_FLAG_NONE, 0, &fileHandle);
     if (err < 0) {
+        if (err == FS_ERROR_INVALID_CLIENTHANDLE) {
+            Finalize();
+            Initialize();
+            err = FSAOpenFileEx(clientHandle, path, "wb", (FSMode) 0x666, FS_OPEN_FLAG_NONE, 0, &fileHandle);
+        }
+    }
+
+    if (err < 0) {
         return err;
     }
 
@@ -85,6 +93,14 @@ int FSUtils::ReadFromFile(const char* path, void* data, uint32_t size)
 
     FSAFileHandle fileHandle;
     FSError err = FSAOpenFileEx(clientHandle, path, "rb", (FSMode) 0x666, FS_OPEN_FLAG_NONE, 0, &fileHandle);
+    if (err < 0) {
+        if (err == FS_ERROR_INVALID_CLIENTHANDLE) {
+            Finalize();
+            Initialize();
+            err = FSAOpenFileEx(clientHandle, path, "rb", (FSMode) 0x666, FS_OPEN_FLAG_NONE, 0, &fileHandle);
+        }
+    }
+
     if (err < 0) {
         return err;
     }


### PR DESCRIPTION
Noticed a bug where after turning the Wii U on, FS Utils had an invalid client handle. This fixes the issue, and loading Skylanders should work immediately after a cold boot.