### PR TITLE
Fix Skylander Creation when no Figure Selected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ WUT_ROOT := $(DEVKITPRO)/wut
 #-------------------------------------------------------------------------------
 export VERSION_MAJOR	:=	0
 export VERSION_MINOR	:=	4
-export VERSION_PATCH	:=	4
+export VERSION_PATCH	:=	5
 
 #-------------------------------------------------------------------------------
 # TARGET is the name of the output

--- a/src/config/ConfigItemSelectSkylander.cpp
+++ b/src/config/ConfigItemSelectSkylander.cpp
@@ -285,6 +285,8 @@ static void enterCreationMenu(ConfigItemSelectSkylander *item) {
     item->currentPath  = item->rootPath + "Skylanders";
     std::filesystem::create_directory(item->currentPath);
     item->currentPath += "/";
+    std::string previousSkylander = item->selectedSkylander;
+    item->selectedSkylander.clear();
 
     while (true) {
         entries.clear();
@@ -405,6 +407,7 @@ static void enterCreationMenu(ConfigItemSelectSkylander *item) {
                     // create a new skylander
                     if (item->selectedSkylander.empty()) {
                         // no skylander selected, just return
+                        item->selectedSkylander = previousSkylander;
                         return;
                     }
                     if (g_skyportal.CreateSkylander(item->selectedSkylander, item->skylanderId.first, item->skylanderId.second)) {
@@ -422,6 +425,7 @@ static void enterCreationMenu(ConfigItemSelectSkylander *item) {
                 // create a new skylander
                 if (item->selectedSkylander.empty()) {
                     // no skylander selected, just return
+                    item->selectedSkylander = previousSkylander;
                     return;
                 }
                 if (g_skyportal.CreateSkylander(item->selectedSkylander, item->skylanderId.first, item->skylanderId.second)) {

--- a/src/devices/Dimensions.cpp
+++ b/src/devices/Dimensions.cpp
@@ -1340,7 +1340,9 @@ void DimensionsToypad::DimensionsMini::Save() {
     }
 
     int result = FSUtils::WriteToFile(filePath.c_str(), data.data(), data.size());
-    DEBUG_FUNCTION_LINE("WriteToFile returned %d", result);
+    if (result < (int) data.size()) {
+        DEBUG_FUNCTION_LINE("Failed to write entire Dimensions file, returned %d", result);
+    }
 }
 
 std::map<const uint32_t, const char *> DimensionsToypad::GetListMinifigs() {

--- a/src/devices/Infinity.cpp
+++ b/src/devices/Infinity.cpp
@@ -911,5 +911,7 @@ void InfinityBase::InfinityFigure::Save() {
     }
 
     int result = FSUtils::WriteToFile(filePath.c_str(), data.data(), data.size());
-    DEBUG_FUNCTION_LINE("WriteToFile returned %d", result);
+    if (result < (int) data.size()) {
+        DEBUG_FUNCTION_LINE("Failed to write entire Infinity file, returned %d", result);
+    }
 }

--- a/src/devices/Skylander.cpp
+++ b/src/devices/Skylander.cpp
@@ -1186,5 +1186,7 @@ void SkylanderPortal::Skylander::Save() {
     }
 
     int result = FSUtils::WriteToFile(filePath.c_str(), data.data(), data.size());
-    DEBUG_FUNCTION_LINE("WriteToFile returned %d", result);
+    if (result < (int) data.size()) {
+        DEBUG_FUNCTION_LINE("Failed to write entire Skylander file, returned %d", result);
+    }
 }


### PR DESCRIPTION
Noticed a bug when you had a Skylander Selected in a slot, and then entered the create menu, if you exited without selecting it would overwrite anyway with Whirlwind. Also adding in logs when writing fails in Skylander Save